### PR TITLE
Fix broken link on first page visit

### DIFF
--- a/src/routes/blog/PostCard.svelte
+++ b/src/routes/blog/PostCard.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div class="post">
-  <a class="post-link" href="blog/{href}"> {title} </a>
+  <a class="post-link" href="/blog/{href}"> {title} </a>
   <span class="date"> {date} </span>
   <p>{summary}</p>
 </div>


### PR DESCRIPTION
On first load of https://liz.sex/blog/, the link to the blog post is https://liz.sex/blog/blog/robust-trust, while it should be https://liz.sex/blog/robust-trust. This change makes it an absolute link, instead of a relative link from https://liz.sex/blog which introduces an additional "blog"